### PR TITLE
feat: Add Markdown export functionality for contributor profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-12
+
+### Changed
+
+- Refactored Home page call-to-action buttons and donation buttons to use the common `Button` component, eliminating duplicate style strings and improving maintainability.
+
 ## [1.4.0] - 2026-07-06
 
 ### Added
@@ -119,7 +125,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Codebase cleanup and structural refactors to remove duplication, improve consistency, and align with the current design system.
 
-[Unreleased]: https://github.com/narainkarthikv/contribution-cards/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/narainkarthikv/contribution-cards/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/narainkarthikv/contribution-cards/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/narainkarthikv/contribution-cards/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/narainkarthikv/contribution-cards/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/narainkarthikv/contribution-cards/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/narainkarthikv/contribution-cards/compare/v1.1.1...v1.2.1
 [1.1.1]: https://github.com/narainkarthikv/contribution-cards/compare/v1.1.0...v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-25
+
+### Added
+
+- Implemented comprehensive Markdown export functionality for contributor profiles with multiple export formats
+  - **Table Format**: Export contributors as a formatted Markdown table with avatars, names, contributions, and repositories
+  - **Card Format**: Export contributors as detailed profile cards with bio and contribution information
+  - **List Format**: Export contributors as a simple bulleted list with contribution counts and repository associations
+  - **Badge Generation**: Generate GitHub contributor badges/shields in Markdown format for README files and documentation
+- Added export dropdown menu to FiltersBar with copy and download options for all formats
+- Export utilities support both individual profile export and bulk export of filtered contributors
+- Exported files are automatically named with format and timestamp for easy organization
+
 ## [1.4.1] - 2026-07-12
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contribution-cards",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contribution-cards",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,0 +1,190 @@
+/**
+ * ExportMenu — Markdown export options dropdown for contributors
+ */
+
+import React, { useRef, useEffect, useState } from 'react';
+import { Download, Copy, Check } from 'lucide-react';
+import type { Contributor } from '../types/github';
+import {
+  exportContributorsMarkdown,
+  downloadMarkdownFile,
+  copyMarkdownToClipboard,
+  type ExportOptions,
+} from '../utils/markdownExport';
+import { IconButton } from '../common';
+
+interface ExportMenuProps {
+  contributors: Contributor[];
+}
+
+export const ExportMenu: React.FC<ExportMenuProps> = React.memo(({ contributors }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  const handleExportFormat = async (
+    format: 'table' | 'card' | 'list',
+    action: 'download' | 'copy'
+  ) => {
+    const options: ExportOptions = {
+      format,
+      includeBadges: false,
+    };
+
+    const result = exportContributorsMarkdown(contributors, options);
+
+    if (action === 'download') {
+      downloadMarkdownFile(result);
+    } else {
+      const success = await copyMarkdownToClipboard(result.content);
+      if (success) {
+        setCopiedId(format);
+        setTimeout(() => setCopiedId(null), 2000);
+      }
+    }
+
+    setIsOpen(false);
+  };
+
+  const handleExportBadges = async (action: 'download' | 'copy') => {
+    const options: ExportOptions = {
+      format: 'list',
+      includeBadges: true,
+    };
+
+    const result = exportContributorsMarkdown(contributors, options);
+
+    if (action === 'download') {
+      downloadMarkdownFile(result);
+    } else {
+      const success = await copyMarkdownToClipboard(result.content);
+      if (success) {
+        setCopiedId('badges');
+        setTimeout(() => setCopiedId(null), 2000);
+      }
+    }
+
+    setIsOpen(false);
+  };
+
+  return (
+    <div ref={menuRef} className='relative'>
+      <IconButton
+        onClick={() => setIsOpen(!isOpen)}
+        variant={isOpen ? 'active' : 'outline'}
+        size='lg'
+        aria-label='Export as Markdown'
+        title='Export contributors as Markdown'
+        aria-expanded={isOpen}
+        aria-haspopup='menu'>
+        <Download size={18} />
+      </IconButton>
+
+      {isOpen && (
+        <div
+          className='absolute right-0 top-full z-50 mt-2 w-max rounded-md border border-[var(--color-border-primary)] bg-[var(--color-surface-primary)] shadow-lg dark:shadow-xl'
+          role='menu'>
+          {/* Table Format */}
+          <div className='flex flex-col border-b border-[var(--color-border-primary)] p-2'>
+            <p className='px-3 py-2 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]'>
+              Table Format
+            </p>
+            <button
+              onClick={() => handleExportFormat('table', 'download')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              <Download size={14} />
+              Download
+            </button>
+            <button
+              onClick={() => handleExportFormat('table', 'copy')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              {copiedId === 'table' ? <Check size={14} className='text-green-500' /> : <Copy size={14} />}
+              {copiedId === 'table' ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+
+          {/* Card Format */}
+          <div className='flex flex-col border-b border-[var(--color-border-primary)] p-2'>
+            <p className='px-3 py-2 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]'>
+              Card Format
+            </p>
+            <button
+              onClick={() => handleExportFormat('card', 'download')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              <Download size={14} />
+              Download
+            </button>
+            <button
+              onClick={() => handleExportFormat('card', 'copy')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              {copiedId === 'card' ? <Check size={14} className='text-green-500' /> : <Copy size={14} />}
+              {copiedId === 'card' ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+
+          {/* List Format */}
+          <div className='flex flex-col border-b border-[var(--color-border-primary)] p-2'>
+            <p className='px-3 py-2 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]'>
+              List Format
+            </p>
+            <button
+              onClick={() => handleExportFormat('list', 'download')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              <Download size={14} />
+              Download
+            </button>
+            <button
+              onClick={() => handleExportFormat('list', 'copy')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              {copiedId === 'list' ? <Check size={14} className='text-green-500' /> : <Copy size={14} />}
+              {copiedId === 'list' ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+
+          {/* Badges Format */}
+          <div className='flex flex-col p-2'>
+            <p className='px-3 py-2 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]'>
+              Badges
+            </p>
+            <button
+              onClick={() => handleExportBadges('download')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              <Download size={14} />
+              Download
+            </button>
+            <button
+              onClick={() => handleExportBadges('copy')}
+              className='flex items-center gap-2 rounded px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]'
+              role='menuitem'>
+              {copiedId === 'badges' ? <Check size={14} className='text-green-500' /> : <Copy size={14} />}
+              {copiedId === 'badges' ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
+ExportMenu.displayName = 'ExportMenu';

--- a/src/components/FiltersBar.tsx
+++ b/src/components/FiltersBar.tsx
@@ -5,8 +5,9 @@
 
 import React, { useCallback, useEffect, useRef } from 'react';
 import { Search, ArrowUp, ArrowDown } from 'lucide-react';
-import type { FilterOptions, SortOption } from '../types/github';
+import type { Contributor, FilterOptions, SortOption } from '../types/github';
 import { FilterDropdown } from './FilterDropdown';
+import { ExportMenu } from './ExportMenu';
 import { IconButton } from '../common';
 
 interface FiltersBarProps {
@@ -14,6 +15,7 @@ interface FiltersBarProps {
   selectedRepositories: string[];
   filters: FilterOptions;
   sortBy: SortOption;
+  contributors: Contributor[];
   onRepositorySelect: (repo: string) => void;
   onFilterChange: (filters: FilterOptions) => void;
   onSortChange: (sort: SortOption) => void;
@@ -28,6 +30,7 @@ export const FiltersBar: React.FC<FiltersBarProps> = React.memo(
     selectedRepositories,
     filters,
     sortBy,
+    contributors,
     onRepositorySelect,
     onFilterChange,
     onSortChange,
@@ -142,6 +145,8 @@ export const FiltersBar: React.FC<FiltersBarProps> = React.memo(
               <ArrowDown size={18} />
             </IconButton>
           </div>
+
+          <ExportMenu contributors={contributors} />
         </div>
       </section>
     );

--- a/src/pages/Contributors.tsx
+++ b/src/pages/Contributors.tsx
@@ -125,6 +125,7 @@ export const ContributorsPage: React.FC = () => {
               selectedRepositories={pageState.selectedRepositories}
               filters={pageState.filters}
               sortBy={pageState.sortBy}
+              contributors={pageState.filteredContributors}
               onRepositorySelect={pageState.selectRepository}
               onFilterChange={pageState.updateFilters}
               onSortChange={pageState.updateSort}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -44,7 +44,7 @@ import {
   APP_REPOSITORY,
   REPOSITORY_LIST,
 } from '../constants/repositories';
-import { FooterLinkColumn, type FooterLinkItem } from '../common';
+import { FooterLinkColumn, type FooterLinkItem, Button } from '../common';
 
 const projectLinks: FooterLinkItem[] = [
   { label: 'Open app', href: '/contributors' },
@@ -414,20 +414,22 @@ export const Home: React.FC = () => {
                 Fox culture glowing. Start with the contributor cards now.
               </p>
               <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
-                <button
-                  onClick={() => navigate('/contributors')}
-                  className='inline-flex items-center gap-2 rounded-md bg-[var(--color-action-default)] px-6 py-3 text-base font-semibold text-[var(--color-text-inverse)] transition-colors hover:bg-[var(--color-action-hover)] active:bg-[var(--color-action-active)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-action-default)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-primary)]'>
+                <Button
+                  variant='primary'
+                  size='md'
+                  onClick={() => navigate('/contributors')}>
                   Open contributors
                   <ArrowRight size={18} />
-                </button>
-                <a
+                </Button>
+                <Button
+                  variant='secondary'
+                  size='md'
                   href={`https://github.com/${APP_REPOSITORY}`}
                   target='_blank'
-                  rel='noopener noreferrer'
-                  className='inline-flex items-center gap-2 rounded-md border border-[var(--color-border-primary)] bg-[var(--color-surface-primary)] px-6 py-3 text-base font-semibold text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-bg-secondary)] active:bg-[var(--color-surface-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-action-default)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-primary)]'>
+                  rel='noopener noreferrer'>
                   <Github size={18} />
                   Star on GitHub
-                </a>
+                </Button>
               </div>
             </div>
           </div>
@@ -450,20 +452,22 @@ export const Home: React.FC = () => {
                 with a coffee or a small pledge.
               </p>
               <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
-                <a
+                <Button
+                  variant='secondary'
+                  size='sm'
                   href='https://ko-fi.com/wisdomfox'
                   target='_blank'
-                  rel='noopener noreferrer'
-                  className='inline-flex items-center gap-2 rounded-md border border-[var(--color-border-primary)] bg-[var(--color-surface-primary)] px-6 py-3 text-sm font-semibold transition-colors hover:bg-[var(--color-bg-secondary)] active:bg-[var(--color-surface-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-action-default)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-primary)]'>
+                  rel='noopener noreferrer'>
                   ☕ Buy us a coffee
-                </a>
-                <a
+                </Button>
+                <Button
+                  variant='primary'
+                  size='sm'
                   href='https://buymeacoffee.com/narainkarthikv'
                   target='_blank'
-                  rel='noopener noreferrer'
-                  className='inline-flex items-center gap-2 rounded-md bg-[var(--color-action-default)] px-6 py-3 text-sm font-semibold text-[var(--color-text-inverse)] transition-colors hover:bg-[var(--color-action-hover)] active:bg-[var(--color-action-active)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-action-default)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-primary)]'>
+                  rel='noopener noreferrer'>
                   💚 Support on Buy Me a Coffee
-                </a>
+                </Button>
               </div>
               <p className='mt-8 text-xs text-[var(--color-text-secondary)]'>
                 Donations are optional. Contribution Cards will always be free

--- a/src/utils/markdownExport.ts
+++ b/src/utils/markdownExport.ts
@@ -1,0 +1,204 @@
+import type { Contributor } from '../types/github';
+
+export interface ExportOptions {
+  format: 'table' | 'card' | 'list';
+  includeBadges: boolean;
+}
+
+export interface MarkdownExportResult {
+  content: string;
+  filename: string;
+}
+
+/**
+ * Generate Markdown table format for contributors
+ */
+function generateMarkdownTable(contributors: Contributor[]): string {
+  if (contributors.length === 0) {
+    return '| Avatar | Name | Contributions | Repositories |\n|--------|------|---------------|---------------|\n';
+  }
+
+  const header = '| Avatar | Name | Contributions | Repositories |\n|--------|------|---------------|---------------|\n';
+  const rows = contributors
+    .map((c) => {
+      const avatar = `![${c.login}](${c.avatarUrl})`;
+      const name = `[${c.name || c.login}](${c.profileUrl})`;
+      const contributions = c.totalContributions || 0;
+      const repos = c.contributions.map((r) => r.repo).join(', ') || 'N/A';
+      return `| ${avatar} | ${name} | ${contributions} | ${repos} |`;
+    })
+    .join('\n');
+
+  return header + rows;
+}
+
+/**
+ * Generate Markdown card format for contributors
+ */
+function generateMarkdownCards(contributors: Contributor[]): string {
+  if (contributors.length === 0) {
+    return '## Contributors\n\nNo contributors to display.\n';
+  }
+
+  const cards = contributors
+    .map((c) => {
+      const header = `### [${c.name || c.login}](${c.profileUrl})`;
+      const avatar = `![Avatar](${c.avatarUrl})`;
+      const bio = c.bio ? `> ${c.bio}` : '';
+      const contributions = `**Contributions:** ${c.totalContributions}`;
+      const repos = c.contributions.length
+        ? `**Repositories:** ${c.contributions.map((r) => r.repo).join(', ')}`
+        : '';
+
+      return [header, avatar, bio, contributions, repos].filter((line) => line).join('\n\n');
+    })
+    .join('\n\n---\n\n');
+
+  return `## Contributors\n\n${cards}\n`;
+}
+
+/**
+ * Generate Markdown list format for contributors
+ */
+function generateMarkdownList(contributors: Contributor[]): string {
+  if (contributors.length === 0) {
+    return '## Contributors\n\nNo contributors to display.\n';
+  }
+
+  const items = contributors
+    .map((c) => {
+      const name = c.name || c.login;
+      const link = `[${name}](${c.profileUrl})`;
+      const contributions = c.totalContributions ? ` - ${c.totalContributions} contributions` : '';
+      const repos = c.contributions.length ? ` in ${c.contributions.map((r) => r.repo).join(', ')}` : '';
+      return `- ${link}${contributions}${repos}`;
+    })
+    .join('\n');
+
+  return `## Contributors\n\n${items}\n`;
+}
+
+/**
+ * Generate GitHub contributor badge/shield for Markdown
+ */
+function generateContributorBadge(contributor: Contributor): string {
+  const badgeUrl = `https://img.shields.io/badge/${encodeURIComponent(contributor.login)}-${encodeURIComponent(
+    contributor.totalContributions.toString()
+  )}_contributions-blue`;
+  return `[![${contributor.login}](${badgeUrl})](${contributor.profileUrl})`;
+}
+
+/**
+ * Generate badge collection for all contributors
+ */
+function generateBadgeCollection(contributors: Contributor[]): string {
+  if (contributors.length === 0) {
+    return '## Contributors\n\nNo contributors to display.\n';
+  }
+
+  const badges = contributors.map((c) => generateContributorBadge(c)).join(' ');
+
+  return `## Contributors\n\n${badges}\n`;
+}
+
+/**
+ * Export a single contributor as Markdown
+ */
+export function exportSingleContributorMarkdown(
+  contributor: Contributor
+): MarkdownExportResult {
+  let content = `# ${contributor.name || contributor.login}\n\n`;
+
+  content += `![${contributor.login}](${contributor.avatarUrl})\n\n`;
+
+  content += `**GitHub Profile:** [${contributor.profileUrl}](${contributor.profileUrl})\n\n`;
+
+  if (contributor.bio) {
+    content += `**Bio:** ${contributor.bio}\n\n`;
+  }
+
+  content += `**Total Contributions:** ${contributor.totalContributions}\n\n`;
+
+  if (contributor.contributions.length) {
+    content += `**Contributed to Repositories:**\n\n${contributor.contributions
+      .map((r) => `- ${r.repo} (${r.commitsCount || 0} commits)`)
+      .join('\n')}\n\n`;
+  }
+
+  const filename = `${contributor.login.replace(/[^a-z0-9]/gi, '_')}_profile.md`;
+
+  return {
+    content,
+    filename,
+  };
+}
+
+/**
+ * Export multiple contributors as Markdown
+ */
+export function exportContributorsMarkdown(
+  contributors: Contributor[],
+  options: ExportOptions
+): MarkdownExportResult {
+  let content = '';
+
+  // Add header
+  content += `# Contributors\n\n`;
+  content += `**Generated:** ${new Date().toISOString()}\n\n`;
+  content += `**Total Contributors:** ${contributors.length}\n\n`;
+
+  // Add badges if requested
+  if (options.includeBadges) {
+    content += `## Badges\n\n${generateBadgeCollection(contributors)}\n\n---\n\n`;
+  }
+
+  // Generate content based on format
+  switch (options.format) {
+    case 'table':
+      content += generateMarkdownTable(contributors);
+      break;
+    case 'card':
+      content += generateMarkdownCards(contributors);
+      break;
+    case 'list':
+      content += generateMarkdownList(contributors);
+      break;
+    default:
+      content += generateMarkdownTable(contributors);
+  }
+
+  const timestamp = new Date().toISOString().split('T')[0];
+  const filename = `contributors_${options.format}_${timestamp}.md`;
+
+  return {
+    content,
+    filename,
+  };
+}
+
+/**
+ * Download Markdown content as a file
+ */
+export function downloadMarkdownFile(result: MarkdownExportResult): void {
+  const element = document.createElement('a');
+  const file = new Blob([result.content], { type: 'text/markdown' });
+
+  element.href = URL.createObjectURL(file);
+  element.download = result.filename;
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+  URL.revokeObjectURL(element.href);
+}
+
+/**
+ * Copy Markdown content to clipboard
+ */
+export async function copyMarkdownToClipboard(content: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(content);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
- Implement multiple export formats (table, card, list, badges)
- Add ExportMenu component with download and copy options
- Support bulk export of filtered contributors with automatic naming
- Generate GitHub contributor badges/shields in Markdown format
- Integrate export button into FiltersBar component
- Update package version to 1.5.0

Resolves #64
